### PR TITLE
fix #8 - pcx.h missing in examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SUBDIRS:= `ls | egrep -v '^(CVS)$$'`
 DATESTRING	:=	$(shell date +%Y%m%d)
 
 all:
+	$(MAKE) -C $(CURDIR)/graphics/PCXView/ || { exit 1;}
 	@for i in $(SUBDIRS); do if test -e $$i/Makefile ; then $(MAKE) -C $$i || { exit 1;} fi; done;
 clean:
 	@for i in $(SUBDIRS); do if test -e $$i/Makefile ; then $(MAKE)  -C $$i clean || { exit 1;} fi; done;

--- a/audio/PlayBoyScout/Makefile
+++ b/audio/PlayBoyScout/Makefile
@@ -100,7 +100,8 @@ endif
 
 export OFILES_BIN := $(addsuffix .o,$(BINFILES))
 
-export OFILES_SOURCES := $(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+export OFILES_SOURCES := $(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o) \
+	$(CURDIR)/../../graphics/PCXView/build/pcx.o
  
 export OFILES := $(OFILES_BIN) $(OFILES_SOURCES)
 
@@ -108,7 +109,8 @@ export HFILES := $(addsuffix .h,$(subst .,_,$(BINFILES)))
 
 export INCLUDE	:=	$(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
-					-I$(CURDIR)/$(BUILD)
+					-I$(CURDIR)/$(BUILD) \
+					-I $(CURDIR)/../../graphics/PCXView/source
  
 export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 

--- a/xboo/XbooLoad/Makefile
+++ b/xboo/XbooLoad/Makefile
@@ -86,14 +86,16 @@ else
 endif
 #---------------------------------------------------------------------------------
 
-export OFILES	:= $(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+export OFILES	:= $(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o) \
+	$(CURDIR)/../../graphics/PCXView/build/pcx.o
 
 #---------------------------------------------------------------------------------
 # build a list of include paths
 #---------------------------------------------------------------------------------
 export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
-					-I$(CURDIR)/$(BUILD)
+					-I$(CURDIR)/$(BUILD) \
+					-I $(CURDIR)/../../graphics/PCXView/source
 
 #---------------------------------------------------------------------------------
 # build a list of library paths


### PR DESCRIPTION
Not super experienced with more complex make examples, but this seems to do the trick with latest devkitpro install via pacman on linux