### PR TITLE
XbooLoad: Inform user about failed dfopen

### DIFF
--- a/xboo/XbooLoad/src/XbooLoad.c
+++ b/xboo/XbooLoad/src/XbooLoad.c
@@ -27,6 +27,11 @@ void LoadPic(void) {
 //---------------------------------------------------------------------------------
 	int handle = dfopen("data\\splash.pcx","rb");
 
+	if (handle == -1) {
+		dprintf("Failed to open data\\splash.pcx");
+		return;
+	}
+
 	dfseek(handle,0,SEEK_END);
 	u32 size = dftell(handle);
 	dprintf("File size is %d\n",size);


### PR DESCRIPTION
The user needs to execute xcomms (or compatible) in the same directory as the files, that are to be opened.
This might not be obvious and failure to do so crashes old xcomms versions.
Print an error message to inform the user about failure to open the pcx file.